### PR TITLE
Fix registration of plugin

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -54,6 +54,6 @@ setup(
         'setuptools',
     ],
     entry_points={
-        'flake8.extension': ['flake8_copyright = flake8_copyright:CopyrightChecker'],
+        'flake8.extension': ['C801 = flake8_copyright:CopyrightChecker'],
     },
 )


### PR DESCRIPTION
According to the flake8 plugin docs, the entry point name should be the error code prefix that will be emitted from the plugin. Otherwise, apparently flake8 will silently discard messages. Fix that by registering under C801.