### PR TITLE
Add documentation about selecting copyright errors

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -19,6 +19,9 @@ Install with pip::
 Then, activate copyright checks in your flake8 configuration with::
 
     copyright-check = True
+    # C errors are not selected by default, so add them to your selection
+    select = E,F,W,C
+
 
 Further options
 ---------------


### PR DESCRIPTION
With flake8==3.5.0, I was confused by copyright errors not being reported.
  $ flake8 -v
  ...
  flake8.main.application   MainProcess    409 INFO     Found a total of 10 violations and reported 0

Eventually I tracked it down to the default selection, and I thought it should be documented.