### PR TITLE
Support for flake8 6.0.0

### DIFF
--- a/flake8_copyright.py
+++ b/flake8_copyright.py
@@ -17,25 +17,8 @@
 #
 
 import re
-import optparse
 
 __version__ = '0.2.3'
-
-
-# Temporary shim for flake8 2.x --> 3.x transition
-# http://flake8.pycqa.org/en/latest/plugin-development/cross-compatibility.html#option-handling-on-flake8-2-and-3
-def register_opt(parser, *args, **kwargs):
-    try:
-        # Flake8 3.x registration
-        parser.add_option(*args, **kwargs)
-    except (optparse.OptionError, TypeError):
-        # Flake8 2.x registration
-        parse_from_config = kwargs.pop('parse_from_config', False)
-        kwargs.pop('comma_separated_list', False)
-        kwargs.pop('normalize_paths', False)
-        parser.add_option(*args, **kwargs)
-        if parse_from_config:
-            parser.config_options.append(args[-1].lstrip('-'))
 
 
 class CopyrightChecker(object):
@@ -49,22 +32,22 @@ class CopyrightChecker(object):
 
     @classmethod
     def add_options(cls, parser):
-        register_opt(
-            parser, '--copyright-check', action='store_true', parse_from_config=True,
+        parser.add_option(
+            '--copyright-check', action='store_true', parse_from_config=True,
             help="Checks for copyright notices in every file."
         )
-        register_opt(
-            parser, '--copyright-min-file-size', default=0, action='store', type='int',
+        parser.add_option(
+            '--copyright-min-file-size', default=0, action='store', type=int,
             parse_from_config=True,
             help="Minimum number of characters in a file before requiring a copyright notice."
         )
-        register_opt(
-            parser, '--copyright-author', default='', action='store',
+        parser.add_option(
+            '--copyright-author', default='', action='store',
             parse_from_config=True,
             help="Checks for a specific author in the copyright notice."
         )
-        register_opt(
-            parser, '--copyright-regexp',
+        parser.add_option(
+            '--copyright-regexp',
             default=r"Copyright\s+(\(C\)\s+)?\d{4}([-,]\d{4})*\s+%(author)s",
             action='store',
             parse_from_config=True,


### PR DESCRIPTION
Closes #19 

Flake8 recently dropped the support for optparse : https://github.com/PyCQA/flake8/pull/1739

I had no time to test this patch. Also it makes `flake8-copyright` incompatible with flake8 2.x