### PR TITLE
Simplify logic and allow any SPDX header by default

### DIFF
--- a/flake8_copyright.py
+++ b/flake8_copyright.py
@@ -1,5 +1,3 @@
-# -=- encoding: utf-8 -=-
-#
 # Copyright (C) 2016 Savoir-faire Linux Inc.
 #
 # This program is free software: you can redistribute it and/or modify
@@ -18,7 +16,8 @@
 
 import re
 
-__version__ = '0.2.4'
+__version__ = '0.3.0'
+DEFAULT_COPYRIGHT_REGEXP = r"Copyright\s+(?:\(C\)\s+)?\d{4}([-,]\d{4})?|SPDX-License-"
 
 
 class CopyrightChecker(object):
@@ -37,18 +36,13 @@ class CopyrightChecker(object):
             help="Checks for copyright notices in every file."
         )
         parser.add_option(
-            '--copyright-min-file-size', default=0, action='store', type=int,
+            '--copyright-min-file-size', default=1024, action='store', type=int,
             parse_from_config=True,
             help="Minimum number of characters in a file before requiring a copyright notice."
         )
         parser.add_option(
-            '--copyright-author', default='', action='store',
-            parse_from_config=True,
-            help="Checks for a specific author in the copyright notice."
-        )
-        parser.add_option(
             '--copyright-regexp',
-            default=r"Copyright\s+(\(C\)\s+)?\d{4}([-,]\d{4})*\s+%(author)s",
+            default=DEFAULT_COPYRIGHT_REGEXP,
             action='store',
             parse_from_config=True,
             help="Changes the copyright regular expression to look for."
@@ -58,18 +52,14 @@ class CopyrightChecker(object):
     def parse_options(cls, options):
         cls.copyright_check = options.copyright_check
         cls.copyright_min_file_size = options.copyright_min_file_size
-        cls.copyright_author = options.copyright_author
-        cls.copyright_regexp = options.copyright_regexp
+        cls.copyright_regexp = re.compile(options.copyright_regexp)
 
     def run(self):
         if not self.copyright_check:
             return
-        toread = max(1024, self.copyright_min_file_size)
-        top_of_file = open(self.filename).read(toread)
+        with open(self.filename) as f:
+            top_of_file = f.read(self.copyright_min_file_size)
         if len(top_of_file) < self.copyright_min_file_size:
             return
-
-        author = self.copyright_author if self.copyright_author else r".*"
-        re_copyright = re.compile(self.copyright_regexp % {'author': author}, re.IGNORECASE)
-        if not re_copyright.search(top_of_file):
+        if not self.copyright_regexp.search(top_of_file):
             yield 1, 1, "C801 Copyright notice not present.", type(self)


### PR DESCRIPTION
As a user, I found the inclusion of _author_ confusing, and I had to check the code to see how it gets included. I think it might be simpler if the regex is the only parameter. There is a common recommendation to just list the authors as "The Authors" or "Contributors to <Project>" anyway, both for legal reasons (sometimes who actually holds the copyright would be decided in court), because lots more people than the authors could hold part of the copyright, because you'd have to update the header if the authors change, and because it's not necessary.

While I was at it, I also set the default min length to 1024, closed the open file handle, dropped the unnecessary encoding header, and included any `SPDX-` header in the default regex.